### PR TITLE
Log all configuration at bot start

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -83,8 +83,7 @@ def main():
         format='%(asctime)s [%(name)s] %(levelname)s: %(message)s',
         )
     logger.info('Starting bot...')
-    logger.info(f'- Log level is {config.LOG_LEVEL}')
-    logger.info(f'- Poll interval is {config.POLL_INTERVAL}')
+    config.log(logger.info)
     updater = Updater(config.TELEGRAM_BOT_TOKEN)
     dp = updater.dispatcher
 


### PR DESCRIPTION
Introduce a wrapper for `prettyconf`'s `config` that keeps a
configuration registry that can be accessed later for logging or,
potentially, printing as command output.

The wrapper accounts for sensitive configuration items and suppresses
their values in output.